### PR TITLE
Feature - increase security

### DIFF
--- a/src/Core/OtpBuilder.php
+++ b/src/Core/OtpBuilder.php
@@ -105,7 +105,7 @@ class OtpBuilder extends OtpUtilities
      */
     private function cacheOtp($otp)
     {
-        $cacheKey = sprintf('%s_%s', $this->prefix, $this->key);
+        $cacheKey = $this->getCacheKey();
 
         cache()->forget($cacheKey);
 

--- a/src/Core/OtpUtilities.php
+++ b/src/Core/OtpUtilities.php
@@ -49,7 +49,7 @@ abstract class OtpUtilities
 
     protected function getCacheKey(): string
     {
-        return sprintf('%s_%s', $this->prefix, $this->key);
+        return md5(sprintf('%s_%s', $this->prefix, $this->key));
     }
 
     abstract public function withDefaultSettings(): self;

--- a/tests/Unit/OtpBuilderTest.php
+++ b/tests/Unit/OtpBuilderTest.php
@@ -24,36 +24,41 @@ class OtpBuilderTest extends TestCase
      */
     public function test_builder_with_default_settings(): void
     {
-
-        $otp = OtpGenerator::createFrom('smth', 'id');
+        $prefix = 'something';
+        $key = 'id'; // $user->id
+        $otp = OtpGenerator::createFrom($prefix, $key);
         $this->assertIsInt($otp);
         $this->assertTrue(strlen(strval($otp))  === config('otp.length')); // ensure otp has 6 digits
-        $this->assertTrue(cache()->has("smth_id"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
-        $otp = OtpGenerator::createFrom('smth', 'email');
+        $key = 'email'; // $user->email
+        $otp = OtpGenerator::createFrom($prefix, $key);
         $this->assertIsInt($otp);
-        $this->assertTrue(cache()->has("smth_email"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
 
-        $otp = OtpGenerator::createFrom('smth', 'username', OtpType::STRING);
+        $key = 'username';// $user->username
+        $otp = OtpGenerator::createFrom($prefix, $key, OtpType::STRING);
         $this->assertIsNotInt($otp);
         $this->assertTrue(strlen($otp) === config('otp.length'));
         $this->assertTrue(is_string($otp));
-        $this->assertTrue(cache()->has("smth_username"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
 
         $length = 12;
-        $otp = OtpGenerator::createFrom('smth', 'custom_key', OtpType::NUMBER, $length, now()->addDay());
+        $key = 'custom_key';
+        $otp = OtpGenerator::createFrom($prefix, $key, OtpType::NUMBER, $length, now()->addDay());
         $this->assertIsInt($otp);
         $this->assertTrue(strlen(strval($otp))  === $length); // ensure otp has 6 digits
-        $this->assertTrue(cache()->has("smth_custom_key"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
         $length = 8;
-        $otp = OtpGenerator::createFrom('smth', 'whatever', OtpType::STRING, $length, now()->addDay());
+        $key = 'whatever';
+        $otp = OtpGenerator::createFrom($prefix, $key, OtpType::STRING, $length, now()->addDay());
         $this->assertIsNotInt($otp);
         $this->assertTrue(strlen($otp) === $length);
         $this->assertTrue(is_string($otp));
-        $this->assertTrue(cache()->has("smth_whatever"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
     }
 
     /**
@@ -67,10 +72,13 @@ class OtpBuilderTest extends TestCase
      */
     public function test_builder_with_custom_settings(): void
     {
+        $prefix = 'dummy_prefix';
+        $key = 'my_custom_key'; // $user->id
+
         $length = 8;
         $otp = OtpGenerator::builder()
-            ->withPrefix('dummy_prefix')
-            ->withKey('my_custom_key')
+            ->withPrefix($prefix)
+            ->withKey($key)
             ->withType(OtpType::NUMBER)
             ->withTtl(now()->addMinutes(2))
             ->withLength($length)
@@ -78,12 +86,13 @@ class OtpBuilderTest extends TestCase
 
         $this->assertIsInt($otp);
         $this->assertTrue(strlen(strval($otp))  === $length); // ensure otp has 6 digits
-
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
         $length = 12;
+        $key = 'anotherthing';
         $otp = OtpGenerator::builder()
-            ->withPrefix('dummy_prefix')
-            ->withKey('my_custom_key')
+            ->withPrefix($prefix)
+            ->withKey($key)
             ->withType(OtpType::STRING)
             ->withTtl(now()->addMinutes(2))
             ->withLength($length)
@@ -93,15 +102,17 @@ class OtpBuilderTest extends TestCase
         $this->assertTrue(strlen($otp) === $length);
         $this->assertTrue(is_string($otp));
 
-        $this->assertTrue(cache()->has("dummy_prefix_my_custom_key"));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', $prefix, $key))));
 
+        $key = 'something_else';
         $otp = OtpGenerator::builder()
             ->withDefaultSettings()
-            ->withKey('my_custom_key')
+            ->withKey($key)
             ->build();
 
         $this->assertIsInt($otp);
         $this->assertTrue(strlen($otp) === config('otp.length'));
+        $this->assertTrue(cache()->has(md5(sprintf('%s_%s', config('otp.cache.prefix'), $key))));
     }
 
     /**

--- a/tests/Unit/OtpResolverTest.php
+++ b/tests/Unit/OtpResolverTest.php
@@ -28,17 +28,20 @@ class OtpResolverTest extends TestCase
     public function test_resolver_with_default_settings(): void
     {
         $key = 'id';
-        $cacheKey = sprintf('%s_%s', config('otp.cache.prefix'), $key);
+        $plainCacheKey = sprintf('%s_%s', config('otp.cache.prefix'), $key);
+        $cacheKey = md5($plainCacheKey);
 
         $otp = OtpGenerator::create($key);
         $this->assertIsInt($otp);
         $this->assertTrue(cache()->has($cacheKey));
+        $this->assertTrue(cache()->missing($plainCacheKey));
 
         $this->assertTrue(OtpGenerator::verify($key, $otp));
         $this->assertTrue(OtpGenerator::get($key) === $otp);
 
         OtpGenerator::forget($key);
         $this->assertTrue(cache()->missing($cacheKey));
+        $this->assertTrue(cache()->missing($plainCacheKey));
 
 
         $otp = OtpGenerator::create($key);
@@ -100,11 +103,13 @@ class OtpResolverTest extends TestCase
         $length = 8;
         $prefix = 'dummy_prefix';
         $key = 'my_custom_key';
-        $cacheKey = sprintf('%s_%s', $prefix, $key);
+        $plainCacheKey = sprintf('%s_%s', $prefix, $key);
+        $cacheKey = md5($plainCacheKey);
 
         $otp = OtpGenerator::createFrom($prefix, $key);
         $this->assertIsInt($otp);
         $this->assertTrue(cache()->has($cacheKey));
+        $this->assertTrue(cache()->missing($plainCacheKey));
 
         // Check using resolve method
         $resolvedOtp = OtpGenerator::resolver()


### PR DESCRIPTION
Don't store any plain cache keys in the cache as it may leak security if somehow someone accesses the cache,